### PR TITLE
Verify server certificate in connectTLS

### DIFF
--- a/ftp-client/ftp-client.cabal
+++ b/ftp-client/ftp-client.cabal
@@ -1,5 +1,5 @@
 name:                ftp-client
-version:             0.5.1.5
+version:             0.6.0.0
 synopsis:            Transfer files with FTP and FTPS
 description:         ftp-client is a library for communicating with an FTP server. It works over both a clear channel or TLS.
 homepage:            https://github.com/flipstone/ftp-client
@@ -21,10 +21,11 @@ library
                      , bytestring >= 0.10.8.2 && < 0.13
                      , network >= 2.6.3.6 && < 3.3
                      , attoparsec >= 0.10 && < 0.15
-                     , crypton-connection >= 0.3 && < 0.4
+                     , crypton-connection >= 0.3 && < 0.5
                      , transformers >= 0.5.6.2 && < 0.7
                      , exceptions >= 0.10.3 && < 0.11
                      , containers >= 0.5.11.0 && < 0.8
+                     , data-default-class >= 0.1.2.0 && < 0.2
 
 test-suite ftp-client-test
   type:                exitcode-stdio-1.0

--- a/ftp-client/src/Network/FTP/Client.hs
+++ b/ftp-client/src/Network/FTP/Client.hs
@@ -58,6 +58,7 @@ module Network.FTP.Client (
     parseMlsxLine
 ) where
 
+import Data.Default.Class (def)
 import qualified Data.ByteString.Char8 as C
 import qualified Data.ByteString as B
 import Data.ByteString (ByteString)
@@ -520,11 +521,7 @@ recvAll h = recvAll' ""
 connectTLS :: MonadIO m => SIO.Handle -> String -> Int -> m Connection
 connectTLS h host portNum = do
     context <- liftIO initConnectionContext
-    let tlsSettings = TLSSettingsSimple
-            { settingDisableCertificateValidation = True
-            , settingDisableSession = False
-            , settingUseServerName = False
-            }
+    let tlsSettings = def
         connectionParams = ConnectionParams
             { connectionHostname = host
             , connectionPort = toEnum . fromEnum $ portNum


### PR DESCRIPTION
~~ftp-client is incompatible with crypton-connection-0.4.~~ While reviewing the
changes necessarily to add compatibility, I noticed that ftp-client doesn't
verify the server certificate. I think this is a bad default. Therefore, I
opted to use the `def` value, which uses certificate validation in the new
release of crypto-connection: [addition of
settingClientSupported](https://github.com/kazu-yamamoto/crypton-connection/pull/3/files#diff-aba34437856a234566e42ae9e4ccbc348e4a9ce62b20873dcbf349cfd528d99dL82).

The use of the `def` type class means that this is less likely to break in the future.

Because this could be a breaking change for consumers, I have changed the version number to 0.6.

EDIT: I have added crypton-connection-0.4 compatibility in v0.5.1.6, retaining previous un-validating behaviour. But the TLS validation issue still remains, of course.