### PR TITLE
exposing handle creation functions and fixed issue in reading multi line response 

### DIFF
--- a/ftp-client/src/Network/FTP/Client.hs
+++ b/ftp-client/src/Network/FTP/Client.hs
@@ -40,6 +40,9 @@ module Network.FTP.Client (
     Handle(..),
     -- * Exceptions
     FTPException(..),
+    -- * System Handle Creation
+    createSIOHandle,
+    createTLSConnection,
     -- * Handle Implementations
     sIOHandleImpl,
     tlsHandleImpl,

--- a/ftp-client/src/Network/FTP/Client.hs
+++ b/ftp-client/src/Network/FTP/Client.hs
@@ -43,6 +43,7 @@ module Network.FTP.Client (
     -- * System Handle Creation
     createSIOHandle,
     createTLSConnection,
+    connectTLS,
     -- * Handle Implementations
     sIOHandleImpl,
     tlsHandleImpl,

--- a/ftp-client/src/Network/FTP/Client.hs
+++ b/ftp-client/src/Network/FTP/Client.hs
@@ -272,8 +272,8 @@ loopMultiLine
 loopMultiLine h code lines = do
     nextLine <- liftIO $ getLineResp h
     let newLines = lines <> [C.dropWhile (== ' ') nextLine]
-        nextCode = C.take 3 nextLine
-    if nextCode == code
+        isLastLine = C.isPrefixOf (code <> " ") nextLine -- Ref for reading multiline response : https://datatracker.ietf.org/doc/html/rfc959#page-36
+    if isLastLine
         then return newLines
         else loopMultiLine h code newLines
 


### PR DESCRIPTION
$1. Exposed below 3 functions to have better control on ftp handle's life-cycle. 
   1. createSIOHandle 
   2. createTLSConnection
   3. connectTLS

$2. Fixed issue in reading multi line response
   eg : for response like below
'220-First Line
220-Second Line
220 Third Line'

 Expected all 3 lines but getting only 2 as code checks for only code of 2 lines.

 But the check should follow https://datatracker.ietf.org/doc/html/rfc959#page-36
  `Thus the format for multi-line replies is that the first line will begin with the exact required reply code, followed immediately by a Hyphen, "-" (also known as Minus), followed by text. The last line will begin with the same code, followed immediately by Space , optionally some text, and the Telnet end-of-line code.`